### PR TITLE
Harden production readiness checks and add full release gate workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,16 @@ jobs:
           VITE_APP_RELEASE: ${{ github.sha }}
         run: npm run check:production
 
+      - name: Check production config shape (release-like)
+        env:
+          VITE_SITE_URL: https://spinescanner.app
+          VITE_BASE_PATH: /
+          VITE_SUPPORT_EMAIL: support@spinescanner.app
+          VITE_ENABLE_SCANNER_DEBUG: 'false'
+          VITE_APP_ENV: production
+          VITE_APP_RELEASE: ${{ github.sha }}
+        run: npm run check:production
+
       - name: Test
         timeout-minutes: 18
         run: npm test

--- a/.github/workflows/release-readiness.yml
+++ b/.github/workflows/release-readiness.yml
@@ -1,0 +1,90 @@
+name: Release readiness
+
+on:
+  workflow_dispatch:
+    inputs:
+      site_url:
+        description: Canonical production origin (for example https://app.example.com)
+        required: true
+        type: string
+      base_path:
+        description: Served base path (must start and end with /)
+        required: true
+        default: /
+        type: string
+      support_email:
+        description: Monitored public support inbox
+        required: true
+        type: string
+
+concurrency:
+  group: release-readiness-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  verify-release:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    env:
+      VITE_SITE_URL: ${{ inputs.site_url }}
+      VITE_BASE_PATH: ${{ inputs.base_path }}
+      VITE_SUPPORT_EMAIL: ${{ inputs.support_email }}
+      VITE_ENABLE_SCANNER_DEBUG: 'false'
+      VITE_SENTRY_DSN: ${{ secrets.VITE_SENTRY_DSN }}
+      VITE_APP_ENV: production
+      VITE_APP_RELEASE: ${{ github.sha }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - run: npm ci
+
+      - name: Check production config
+        run: npm run check:production
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Unit tests
+        run: npm run test
+
+      - name: Build
+        run: npm run build
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+
+      - name: E2E release smoke
+        env:
+          CI: 'true'
+          PLAYWRIGHT_HTML_REPORT: playwright-report-release-smoke
+        run: npm run test:e2e:release
+
+      - name: E2E desktop baseline
+        env:
+          CI: 'true'
+          PLAYWRIGHT_HTML_REPORT: playwright-report-desktop
+        run: npm run test:e2e:desktop
+
+      - name: E2E mobile matrix
+        env:
+          CI: 'true'
+          PLAYWRIGHT_HTML_REPORT: playwright-report-mobile
+        run: npm run test:e2e:mobile
+
+      - name: Upload Playwright reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-reports-${{ github.run_id }}
+          path: |
+            playwright-report-release-smoke
+            playwright-report-desktop
+            playwright-report-mobile

--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ VITE_SUPABASE_ANON_KEY=your-anon-key
 
 ## Deployment
 
-The app auto-deploys to GitHub Pages on push to `main` via GitHub Actions. The workflow installs dependencies, builds, and uploads to Pages.
+The default production deployment target is Vercel. Pushes to `main` trigger Vercel production deploys for the connected project (`docs/RELEASING.md`).
+
+The repository still includes a manual GitHub Pages workflow (`.github/workflows/deploy.yml`) for fallback/static-hosting scenarios.
 
 ### Public Launch Configuration
 
@@ -150,7 +152,7 @@ VITE_ENABLE_SCANNER_DEBUG=false
 VITE_APP_ENV=production
 ```
 
-The app now includes footer-linked About, Privacy, Terms, and Support pages, plus social metadata, a share preview image, generated `robots.txt`, and a generated `sitemap.xml`. If you deploy somewhere other than GitHub Pages, keep one canonical public URL, set `VITE_SITE_URL` to it, and set `VITE_BASE_PATH` to the path segment you actually serve from.
+The app now includes footer-linked About, Privacy, Terms, and Support pages, plus social metadata, a share preview image, generated `robots.txt`, and a generated `sitemap.xml`. Keep one canonical public URL, set `VITE_SITE_URL` to it, and set `VITE_BASE_PATH` to the path segment you actually serve from.
 
 For monitoring, `VITE_APP_RELEASE` can be injected by CI so Sentry events can be grouped by deployed revision.
 
@@ -161,6 +163,7 @@ For monitoring, `VITE_APP_RELEASE` can be injected by CI so Sentry events can be
 
 Run `npm run check:production` before production builds to catch missing or risky public-site configuration.
 Run `npm run test:e2e:release` before launch candidates to verify the current release shell, navigation, and support diagnostics path.
+For a full pre-release gate (lint, unit tests, build, desktop + mobile E2E), run the manual GitHub Action `.github/workflows/release-readiness.yml`.
 
 ## Mobile Validation
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,4 +23,10 @@ export default defineConfig([
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
     },
   },
+  {
+    files: ['scripts/**/*.{ts,mts,cts}'],
+    languageOptions: {
+      globals: globals.node,
+    },
+  },
 ])

--- a/scripts/__tests__/checkProductionReadiness.test.ts
+++ b/scripts/__tests__/checkProductionReadiness.test.ts
@@ -1,0 +1,109 @@
+import { spawnSync } from 'node:child_process';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const scriptPath = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  '../check-production-readiness.mjs',
+);
+
+type CheckResult = {
+  status: number;
+  stdout: string;
+  stderr: string;
+};
+
+function runCheck(overrides: Record<string, string | undefined>): CheckResult {
+  const result = spawnSync(process.execPath, [scriptPath], {
+    env: { ...process.env, ...overrides },
+    encoding: 'utf8',
+  });
+
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+}
+
+const validProductionEnv = {
+  VITE_SITE_URL: 'https://app.spinescanner.dev',
+  VITE_BASE_PATH: '/',
+  VITE_SUPPORT_EMAIL: 'support@spinescanner.dev',
+  VITE_ENABLE_SCANNER_DEBUG: 'false',
+  VITE_APP_ENV: 'production',
+  VITE_APP_RELEASE: 'abc123',
+  VITE_SENTRY_DSN: '',
+  VITE_APP_MODE: '',
+};
+
+describe('check-production-readiness script', () => {
+  it('passes for valid production values', () => {
+    const result = runCheck(validProductionEnv);
+
+    expect(result.status).toBe(0);
+    expect(result.stdout).toContain('Production readiness check passed.');
+  });
+
+  it('fails when production uses example.com as site URL', () => {
+    const result = runCheck({
+      ...validProductionEnv,
+      VITE_SITE_URL: 'https://example.com',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('VITE_SITE_URL cannot use example.com in production.');
+  });
+
+  it('fails when production uses localhost as site URL', () => {
+    const result = runCheck({
+      ...validProductionEnv,
+      VITE_SITE_URL: 'http://localhost:4173',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('VITE_SITE_URL cannot target localhost in production.');
+  });
+
+  it('fails when production uses placeholder support email', () => {
+    const result = runCheck({
+      ...validProductionEnv,
+      VITE_SUPPORT_EMAIL: 'noreply@example.com',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('VITE_SUPPORT_EMAIL cannot use example.* placeholder domains in production.');
+  });
+
+  it('allows placeholder values outside production environment', () => {
+    const result = runCheck({
+      ...validProductionEnv,
+      VITE_APP_ENV: 'test',
+      VITE_SITE_URL: 'https://example.com',
+      VITE_SUPPORT_EMAIL: 'noreply@example.com',
+    });
+
+    expect(result.status).toBe(0);
+  });
+
+  it('fails when Sentry DSN is not a valid URL', () => {
+    const result = runCheck({
+      ...validProductionEnv,
+      VITE_SENTRY_DSN: 'not-a-url',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('VITE_SENTRY_DSN must be a valid URL when set.');
+  });
+
+  it('fails when production release id is missing', () => {
+    const result = runCheck({
+      ...validProductionEnv,
+      VITE_APP_RELEASE: '',
+    });
+
+    expect(result.status).toBe(1);
+    expect(result.stderr).toContain('VITE_APP_RELEASE must be set when VITE_APP_ENV=production.');
+  });
+});

--- a/scripts/check-production-readiness.mjs
+++ b/scripts/check-production-readiness.mjs
@@ -76,6 +76,16 @@ function validateDebugFlag(rawValue) {
 function validateMonitoring(rawValue) {
   if (!rawValue) {
     addWarning('VITE_SENTRY_DSN is not set. Production monitoring will be limited.');
+    return;
+  }
+
+  try {
+    const parsed = new URL(rawValue);
+    if (!['http:', 'https:'].includes(parsed.protocol)) {
+      addError('VITE_SENTRY_DSN must use http or https when set.');
+    }
+  } catch {
+    addError('VITE_SENTRY_DSN must be a valid URL when set.');
   }
 }
 
@@ -105,6 +115,64 @@ function validateAppMode(rawValue) {
   }
 }
 
+function isPlaceholderHost(rawValue) {
+  if (!rawValue) return false;
+  try {
+    const parsed = new URL(rawValue);
+    return parsed.hostname === 'example.com' || parsed.hostname.endsWith('.example.com');
+  } catch {
+    return false;
+  }
+}
+
+function isLocalhostHost(rawValue) {
+  if (!rawValue) return false;
+  try {
+    const parsed = new URL(rawValue);
+    return ['localhost', '127.0.0.1', '0.0.0.0'].includes(parsed.hostname);
+  } catch {
+    return false;
+  }
+}
+
+function isPlaceholderSupportEmail(rawValue) {
+  if (!rawValue) return false;
+  const normalized = rawValue.toLowerCase();
+  return (
+    normalized === 'noreply@example.com' ||
+    normalized.endsWith('@example.com') ||
+    normalized.endsWith('@example.org') ||
+    normalized.endsWith('@example.net')
+  );
+}
+
+function validateProductionValues(appEnvironment, siteUrl, supportEmail, appRelease) {
+  if (appEnvironment !== 'production') {
+    return;
+  }
+
+  if (!siteUrl) {
+    addError('VITE_SITE_URL must be set to the real production origin when VITE_APP_ENV=production.');
+  } else {
+    if (isPlaceholderHost(siteUrl)) {
+      addError('VITE_SITE_URL cannot use example.com in production.');
+    }
+    if (isLocalhostHost(siteUrl)) {
+      addError('VITE_SITE_URL cannot target localhost in production.');
+    }
+  }
+
+  if (!supportEmail) {
+    addError('VITE_SUPPORT_EMAIL must be set to a monitored inbox when VITE_APP_ENV=production.');
+  } else if (isPlaceholderSupportEmail(supportEmail)) {
+    addError('VITE_SUPPORT_EMAIL cannot use example.* placeholder domains in production.');
+  }
+
+  if (!appRelease) {
+    addError('VITE_APP_RELEASE must be set when VITE_APP_ENV=production.');
+  }
+}
+
 const siteUrl = readEnv('VITE_SITE_URL');
 const basePath = readEnv('VITE_BASE_PATH');
 const supportEmail = readEnv('VITE_SUPPORT_EMAIL');
@@ -122,6 +190,7 @@ validateMonitoring(sentryDsn);
 validateAppEnvironment(appEnvironment);
 validateRelease(appRelease);
 validateAppMode(appMode);
+validateProductionValues(appEnvironment, siteUrl, supportEmail, appRelease);
 
 if (errors.length > 0) {
   console.error('Production readiness check failed:\n');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- harden `npm run check:production` so `VITE_APP_ENV=production` now fails on placeholder/unsafe values (`example.com`, localhost, placeholder support emails) and requires `VITE_APP_RELEASE`
- validate `VITE_SENTRY_DSN` format when set and add focused Vitest coverage for production-readiness script behavior
- add a manual `.github/workflows/release-readiness.yml` workflow that executes the launch gate (check:production, lint, unit tests, build, release smoke, desktop E2E, mobile E2E) with caller-provided production URL/base path/support inbox
- align docs to production reality: README now states Vercel as default deployment target and links the new release-readiness workflow
- add ESLint node globals override for `scripts/**` tests

## Checklist

- [ ] CI is green (Lint, Test & Build)
- [ ] Updated **CHANGELOG.md** `## Unreleased` if the change is user-facing
- [ ] Ran or verified the **E2E MVP workflow** if this PR touches `appMode`, navigation, profile, or library behavior
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af30020b-6243-4289-81c4-8ab73ecfaf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af30020b-6243-4289-81c4-8ab73ecfaf1d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

