### PR TITLE
chore: set up dev environment and fix scanner route navigation

### DIFF
--- a/e2e/app.spec.ts
+++ b/e2e/app.spec.ts
@@ -56,6 +56,16 @@ test.describe('SpineScanner release smoke', () => {
     await expect(page.getByRole('button', { name: /clear all local data/i })).toBeVisible();
   });
 
+  test('profile route renders after visiting scanner', async ({ page }) => {
+    await page.getByTestId(uiContracts.navTabTestId('scan')).click();
+    await expect(page.getByRole('heading', { name: /three easy ways to capture a book/i })).toBeVisible();
+
+    await page.getByTestId(uiContracts.navTabTestId('profile')).click();
+    await expect(page).toHaveURL(/\/spine-scanner\/profile$/);
+    await expect(page.locator('#profile-settings-title')).toBeVisible();
+    await expect(page.getByRole('heading', { name: /three easy ways to capture a book/i })).toBeHidden();
+  });
+
   test('library review query loads without error', async ({ page }) => {
     await page.goto('./library?review=1');
     await dismissOnboardingIfPresent(page);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "spine-scanner",
-  "version": "1.1.0",
+  "version": "1.2.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "spine-scanner",
-      "version": "1.1.0",
+      "version": "1.2.2",
       "hasInstallScript": true,
       "dependencies": {
         "@sentry/react": "^10.45.0",
@@ -45,6 +45,9 @@
         "vite": "^7.2.4",
         "vite-plugin-pwa": "^1.2.0",
         "vitest": "^4.0.18"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@adobe/css-tools": {

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -12,7 +12,7 @@ initErrorMonitoring();
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter basename={getRouterBasename()}>
+    <BrowserRouter basename={getRouterBasename()} unstable_useTransitions={false}>
       <ToastProvider>
         <App />
       </ToastProvider>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Set up and verified the SpineScanner development environment. Sync `package-lock.json` root package metadata with `package.json`, install Playwright Chromium for local e2e checks, and fix a React Router transition issue that left rendered content stuck on the scanner route after navigating away.

[spine_scanner_live_dev_navigation_demo.mp4](https://cursor.com/agents/bc-4d567dba-02f0-44e2-affb-44be2ded71e8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fspine_scanner_live_dev_navigation_demo.mp4)

## Checklist

- [x] CI is green (Lint, Test & Build)
- [ ] Updated **CHANGELOG.md** `## Unreleased` if the change is user-facing
- [x] Ran or verified the **E2E MVP workflow** if this PR touches `appMode`, navigation, profile, or library behavior

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d567dba-02f0-44e2-affb-44be2ded71e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d567dba-02f0-44e2-affb-44be2ded71e8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

