### PR TITLE
fix: resolve E2E strict mode violation in ocr-upload test

### DIFF
--- a/e2e/ocr-upload.spec.ts
+++ b/e2e/ocr-upload.spec.ts
@@ -12,7 +12,7 @@ test.describe('OCR photo upload', () => {
     await page.goto('/');
     await page.waitForLoadState('domcontentloaded');
     // Ensure SpineScanner app loaded (not another app on same port)
-    await expect(page.getByText(/SpineScanner|Scan Book Spine/i)).toBeVisible({
+    await expect(page.getByText(/SpineScanner|Scan Book Spine/i).first()).toBeVisible({
       timeout: 15000,
     });
   });


### PR DESCRIPTION
`getByText(/SpineScanner|Scan Book Spine/i)` matched 2 elements (header + footer). Added `.first()` to fix Playwright strict mode violation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix strict mode violation in OCR upload E2E test by targeting first matching element
> The `beforeEach` hook in [ocr-upload.spec.ts](https://github.com/hondoentertainment/spine-scanner/pull/76/files#diff-37353f918736a99cf69d12b114778dcf376d5ea3b78682a14e22a85344becaf3) was failing when multiple elements matched the `/SpineScanner|Scan Book Spine/i` locator. Appending `.first()` to the locator resolves the Playwright strict mode error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9ccd4db.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->