### PR TITLE
fix(e2e): resolve SpineScanner strict-mode locator in OCR upload spec

### DIFF
--- a/e2e/ocr-upload.spec.ts
+++ b/e2e/ocr-upload.spec.ts
@@ -9,10 +9,16 @@ const FIXTURE_PATH = join(__dirname, 'fixtures', 'book-spine-isbn.png');
 
 test.describe('OCR photo upload', () => {
   test.beforeEach(async ({ page }) => {
-    await page.goto('/');
+    await page.addInitScript(() => {
+      localStorage.setItem(
+        'spine-scanner-preferences',
+        JSON.stringify({ state: { preferences: { onboardingCompleted: true } }, version: 0 }),
+      );
+    });
+    await page.goto('./scan');
     await page.waitForLoadState('domcontentloaded');
-    // Ensure SpineScanner app loaded (not another app on same port)
-    await expect(page.getByText(/SpineScanner|Scan Book Spine/i)).toBeVisible({
+    // Use the page h1 — getByText(/SpineScanner/) matches meta tags and nav copy (strict mode).
+    await expect(page.getByRole('heading', { level: 1, name: /spinescanner/i })).toBeVisible({
       timeout: 15000,
     });
   });
@@ -46,7 +52,7 @@ test.describe('OCR photo upload', () => {
 
     // Use the file input directly (hidden; setInputFiles works). First input is for ISBN scan.
     const fileInput = page.getByTestId(uiContracts.scannerFileInputTestId).first();
-    await expect(fileInput).toHaveCount(1);
+    await expect(fileInput).toBeAttached();
     await fileInput.setInputFiles(FIXTURE_PATH);
 
     // OCR runs (15–45s first load, up to 2 min in CI); when ISBN found, onScan fires -> Google Books lookup -> "Added X to library"
@@ -55,8 +61,8 @@ test.describe('OCR photo upload', () => {
     });
 
     // Verify book appears in library
-    await page.getByTestId(uiContracts.navTabTestId('library')).click();
-    await expect(page.getByRole('heading', { name: /Your Library/ })).toBeVisible();
+    await page.goto('./library');
+    await expect(page.getByRole('heading', { name: /Your Library/i })).toBeVisible();
     await expect(page.getByText(mockTitle)).toBeVisible({ timeout: 5000 });
   });
 });


### PR DESCRIPTION
## Summary
- Targets the scan page h1 instead of getByText(/SpineScanner/) which matched meta tags and nav copy (Playwright strict mode violation).
- Skips onboarding via localStorage and navigates to ./scan before the OCR upload test.

## Test plan
- [ ] OCR Heavy Checks workflow passes on merge

Made with [Cursor](https://cursor.com)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix strict-mode locator failures in SpineScanner OCR upload e2e spec
> - Pre-seeds `spine-scanner-preferences` in localStorage via `page.addInitScript` to bypass onboarding, and navigates directly to `./scan` instead of `/'`.
> - Replaces the broad `getByText` app-loaded assertion with a scoped H1 role check matching `/spinescanner/i`.
> - Swaps `toHaveCount(1)` for `toBeAttached()` on the file input and navigates to `./library` via URL instead of clicking a nav tab by test ID.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d923cef.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->