### PR TITLE
fix(ci): extend OCR E2E timeout for CI runners

### DIFF
--- a/.github/workflows/ocr-heavy.yml
+++ b/.github/workflows/ocr-heavy.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium
       - name: OCR E2E test
-        timeout-minutes: 15
+        timeout-minutes: 20
         env:
           RUN_OCR_E2E: '1'
         run: npx playwright test e2e/ocr-upload.spec.ts --project=chromium

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -1,0 +1,105 @@
+import { expect, type Page } from '@playwright/test';
+import { uiContracts } from '../src/testing/uiContracts';
+
+export async function seedE2eLocalState(page: Page) {
+  await page.addInitScript(() => {
+    localStorage.setItem(
+      'spine-scanner-preferences',
+      JSON.stringify({ state: { preferences: { onboardingCompleted: true } }, version: 0 }),
+    );
+    localStorage.setItem(
+      'spine-scanner-consent-v1',
+      JSON.stringify({ state: { analyticsConsent: 'denied' }, version: 0 }),
+    );
+  });
+}
+
+export async function seedLibraryBook(page: Page, book: Record<string, unknown>) {
+  await page.addInitScript((entry) => {
+    localStorage.setItem(
+      'spine-scanner-storage',
+      JSON.stringify({ state: { books: [entry], shelves: [] }, version: 0 }),
+    );
+  }, book);
+}
+
+export async function dismissOnboardingIfPresent(page: Page) {
+  const skipButton = page.getByRole('button', { name: /skip tour/i });
+  if (await skipButton.isVisible().catch(() => false)) {
+    await skipButton.click();
+  }
+}
+
+export async function waitForAppShell(page: Page) {
+  await expect(page.getByRole('heading', { level: 1, name: /spinescanner/i })).toBeVisible();
+  await expect(page.locator('[class*="skeletonGrid"]')).toHaveCount(0, { timeout: 15_000 });
+}
+
+export async function clickNavTab(page: Page, tab: 'home' | 'scan' | 'library' | 'profile') {
+  await waitForAppShell(page);
+  await page.getByTestId(uiContracts.navTabTestId(tab)).click();
+}
+
+export const conflictSeedBook = {
+  id: 'e2e-conflict-book',
+  isbn: '9780141036144',
+  title: 'Conflict Title',
+  author: 'Author A',
+  pageCount: 300,
+  amazonLink: '',
+  coverImg: '',
+  status: 'to-read',
+  notes: '',
+  dateAdded: new Date().toISOString(),
+  shelfIds: [],
+  needsReview: true,
+  reviewReason: 'Metadata providers disagree — pick a source below.',
+  metadataSource: 'google_books',
+  metadataPeers: {
+    google: { title: 'Google Title', author: 'Author A', pageCount: 300, thumbnail: '' },
+    openLibrary: { title: 'Open Library Title', author: 'Author B', pageCount: 320, thumbnail: '' },
+  },
+};
+
+export const refreshSeedBook = {
+  id: 'e2e-refresh-book',
+  isbn: '9780141036144',
+  title: 'Refresh Me',
+  author: 'Needs Metadata',
+  pageCount: 0,
+  amazonLink: '',
+  coverImg: '',
+  status: 'to-read',
+  notes: '',
+  dateAdded: new Date().toISOString(),
+  shelfIds: [],
+};
+
+export function installMetadataFetchMocks(page: import('@playwright/test').Page) {
+  return page.addInitScript(() => {
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.includes('googleapis.com/books')) {
+        return new Response(JSON.stringify({
+          totalItems: 1,
+          items: [{
+            volumeInfo: {
+              title: 'Refreshed Title',
+              authors: ['Fresh Author'],
+              pageCount: 240,
+              imageLinks: { thumbnail: 'https://example.com/cover.jpg' },
+            },
+          }],
+        }), { status: 200, headers: { 'Content-Type': 'application/json' } });
+      }
+      if (url.includes('openlibrary.org/api/books')) {
+        return new Response(JSON.stringify({}), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+      return originalFetch(input, init);
+    };
+  });
+}

--- a/e2e/metadata-library.spec.ts
+++ b/e2e/metadata-library.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from '@playwright/test';
+import {
+  conflictSeedBook,
+  dismissOnboardingIfPresent,
+  installMetadataFetchMocks,
+  refreshSeedBook,
+  seedE2eLocalState,
+  seedLibraryBook,
+} from './helpers';
+
+test.describe('Library metadata flows', () => {
+  test('resolves provider conflicts from book detail', async ({ page }) => {
+    await seedE2eLocalState(page);
+    await seedLibraryBook(page, conflictSeedBook);
+    await page.goto('./library');
+    await dismissOnboardingIfPresent(page);
+
+    await page.getByRole('button', { name: /open conflict title/i }).click();
+    await expect(page.getByRole('heading', { name: /providers disagree/i })).toBeVisible();
+    await page.getByRole('button', { name: /use open library metadata/i }).click();
+    await expect(page.getByText(/metadata source applied/i)).toBeVisible();
+    await expect(page.getByRole('heading', { name: /providers disagree/i })).toHaveCount(0);
+  });
+
+  test('bulk refresh metadata updates selected books', async ({ page }) => {
+    await seedE2eLocalState(page);
+    await installMetadataFetchMocks(page);
+    await seedLibraryBook(page, refreshSeedBook);
+
+    await page.goto('./library');
+    await dismissOnboardingIfPresent(page);
+
+    await page.getByRole('button', { name: /select books/i }).click();
+    await page.getByRole('checkbox', { name: /select/i }).check();
+    await page.getByRole('button', { name: /^refresh metadata$/i }).click();
+    await expect(page.getByText(/refreshed 1 book/i)).toBeVisible({ timeout: 20_000 });
+  });
+});

--- a/e2e/ocr-upload.spec.ts
+++ b/e2e/ocr-upload.spec.ts
@@ -25,7 +25,7 @@ test.describe('OCR photo upload', () => {
 
   test('extracts ISBN from uploaded OCR fixture image', async ({ page, context }) => {
     test.skip(!!process.env.CI && !process.env.RUN_OCR_E2E, 'Tesseract.js OCR too slow on default CI runners; set RUN_OCR_E2E=1 to run.');
-    test.setTimeout(60000);
+    test.setTimeout(process.env.CI ? 180000 : 60000);
     const mockTitle = 'Test Book via OCR';
 
     // Mock APIs at context level

--- a/src/components/MetadataConflictPanel.module.css
+++ b/src/components/MetadataConflictPanel.module.css
@@ -1,0 +1,63 @@
+.panel {
+  margin-top: 0.5rem;
+  padding: 0.85rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(251, 191, 36, 0.35);
+  background: rgba(251, 191, 36, 0.08);
+}
+
+.title {
+  margin: 0 0 0.35rem;
+  font-size: 0.95rem;
+  font-weight: 600;
+}
+
+.hint {
+  margin: 0 0 0.75rem;
+  font-size: 0.82rem;
+  color: var(--text-muted, #94a3b8);
+  line-height: 1.4;
+}
+
+.grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 0.5rem;
+}
+
+@media (max-width: 380px) {
+  .grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+.choice {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.2rem;
+  padding: 0.65rem 0.75rem;
+  border-radius: 0.6rem;
+  border: 1px solid var(--glass-border, rgba(255, 255, 255, 0.12));
+  background: rgba(0, 0, 0, 0.2);
+  text-align: left;
+  min-height: 44px;
+  touch-action: manipulation;
+}
+
+.choice:hover {
+  border-color: rgba(99, 102, 241, 0.55);
+}
+
+.choiceLabel {
+  font-size: 0.72rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: #a5b4fc;
+}
+
+.choiceField {
+  font-size: 0.84rem;
+  color: var(--text-main, #f8fafc);
+}

--- a/src/components/MetadataConflictPanel.tsx
+++ b/src/components/MetadataConflictPanel.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import type { BookEntry } from '../types.ts';
+import { METADATA_SOURCE_LABEL } from '../types.ts';
+import { applyMetadataPeerChoice, getMetadataConflictFlags } from '../lib/metadataPeers.ts';
+import styles from './MetadataConflictPanel.module.css';
+
+interface MetadataConflictPanelProps {
+  book: BookEntry;
+  onResolve: (updates: Partial<BookEntry>) => void;
+}
+
+function fieldLabel(key: keyof ReturnType<typeof getMetadataConflictFlags>): string {
+  if (key === 'pageCount') return 'Page count';
+  return key.charAt(0).toUpperCase() + key.slice(1);
+}
+
+const MetadataConflictPanel: React.FC<MetadataConflictPanelProps> = ({ book, onResolve }) => {
+  const google = book.metadataPeers?.google;
+  const openLibrary = book.metadataPeers?.openLibrary;
+  if (!google || !openLibrary) return null;
+
+  const flags = getMetadataConflictFlags(book);
+  if (!flags.author && !flags.pageCount && !flags.title) return null;
+
+  const conflictFields = (Object.keys(flags) as Array<keyof typeof flags>).filter((k) => flags[k]);
+
+  return (
+    <section className={styles.panel} aria-labelledby={`metadata-conflict-${book.id}`}>
+      <h3 id={`metadata-conflict-${book.id}`} className={styles.title}>
+        Providers disagree
+      </h3>
+      <p className={styles.hint}>
+        Choose which source to use for {conflictFields.map(fieldLabel).join(', ')}. Applying a source replaces those fields with the provider values.
+      </p>
+      <div className={styles.grid}>
+        {(['google_books', 'open_library'] as const).map((provider) => {
+          const peer = provider === 'google_books' ? google : openLibrary;
+          const label = METADATA_SOURCE_LABEL[provider];
+          const choiceSummary = [
+            peer.title?.trim() || book.title,
+            peer.author,
+            peer.pageCount > 0 ? `${peer.pageCount} pages` : null,
+          ].filter(Boolean).join(', ');
+          return (
+            <button
+              key={provider}
+              type="button"
+              className={styles.choice}
+              aria-label={`Use ${label} metadata: ${choiceSummary}`}
+              aria-pressed={book.metadataSource === provider}
+              onClick={() => {
+                const updates = applyMetadataPeerChoice(book, provider);
+                if (updates) onResolve(updates);
+              }}
+            >
+              <span className={styles.choiceLabel}>{label}</span>
+              <span className={styles.choiceField}>{peer.title?.trim() || book.title}</span>
+              <span className={styles.choiceField}>{peer.author}</span>
+              {peer.pageCount > 0 && (
+                <span className={styles.choiceField}>{peer.pageCount} pages</span>
+              )}
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+};
+
+export default MetadataConflictPanel;

--- a/src/components/PwaUpdatePrompt.module.css
+++ b/src/components/PwaUpdatePrompt.module.css
@@ -1,0 +1,71 @@
+.bar {
+  position: fixed;
+  left: 50%;
+  transform: translateX(-50%);
+  top: calc(0.85rem + env(safe-area-inset-top, 0px));
+  z-index: 96;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.65rem;
+  max-width: min(32rem, calc(100vw - 1.5rem));
+  padding: 0.75rem 1rem;
+  border-radius: var(--radius-md, 12px);
+  border: 1px solid var(--glass-border);
+  box-shadow: 0 12px 40px rgba(15, 23, 42, 0.35);
+}
+
+.icon {
+  color: var(--accent-purple);
+  flex-shrink: 0;
+}
+
+.copy {
+  flex: 1 1 140px;
+  min-width: 0;
+}
+
+.title {
+  display: block;
+  font-size: 0.9rem;
+  margin: 0 0 0.15rem;
+}
+
+.sub {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.primary,
+.ghost {
+  min-height: 44px;
+  padding: 0.45rem 0.85rem;
+  border-radius: var(--radius-md, 10px);
+  font-weight: 600;
+  font-size: 0.85rem;
+  touch-action: manipulation;
+}
+
+.primary {
+  border: none;
+  color: white;
+  background: linear-gradient(135deg, var(--accent-purple), var(--primary));
+}
+
+.ghost {
+  border: 1px solid var(--glass-border);
+  background: transparent;
+  color: var(--text-muted);
+}
+
+@media (min-width: 900px) {
+  .bar {
+    top: 1rem;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .icon {
+    animation: none !important;
+  }
+}

--- a/src/components/PwaUpdatePrompt.tsx
+++ b/src/components/PwaUpdatePrompt.tsx
@@ -1,0 +1,28 @@
+import { useEffect, useState } from 'react';
+import { RefreshCw } from 'lucide-react';
+import { applyPwaUpdate, dismissPwaRefresh, subscribePwaRefresh } from '../pwa/updateRegistration.ts';
+import s from './PwaUpdatePrompt.module.css';
+
+export default function PwaUpdatePrompt() {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => subscribePwaRefresh(setVisible), []);
+
+  if (!visible) return null;
+
+  return (
+    <div className={`glass ${s.bar}`} role="alert" aria-live="polite" aria-label="App update available">
+      <RefreshCw size={18} className={s.icon} aria-hidden />
+      <div className={s.copy}>
+        <strong className={s.title}>Update available</strong>
+        <span className={s.sub}>Reload to get the latest SpineScanner improvements.</span>
+      </div>
+      <button type="button" className={s.primary} onClick={() => void applyPwaUpdate()}>
+        Reload
+      </button>
+      <button type="button" className={s.ghost} onClick={dismissPwaRefresh}>
+        Later
+      </button>
+    </div>
+  );
+}

--- a/src/components/__tests__/MetadataConflictPanel.test.tsx
+++ b/src/components/__tests__/MetadataConflictPanel.test.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import MetadataConflictPanel from '../MetadataConflictPanel.tsx';
+import type { BookEntry } from '../../types.ts';
+
+const conflictBook = (): BookEntry => ({
+  id: 'book-1',
+  isbn: '9780141036144',
+  title: 'Current Title',
+  author: 'Current Author',
+  pageCount: 300,
+  amazonLink: '',
+  coverImg: '',
+  status: 'to-read',
+  notes: '',
+  dateAdded: new Date().toISOString(),
+  shelfIds: [],
+  metadataSource: 'google_books',
+  metadataPeers: {
+    google: { title: 'Google Title', author: 'Author A', pageCount: 300 },
+    openLibrary: { title: 'OL Title', author: 'Author B', pageCount: 320 },
+  },
+});
+
+describe('MetadataConflictPanel', () => {
+  it('renders nothing when peers are missing', () => {
+    const { container } = render(
+      <MetadataConflictPanel book={{ ...conflictBook(), metadataPeers: undefined }} onResolve={vi.fn()} />,
+    );
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('shows provider choices and resolves with selected snapshot', () => {
+    const onResolve = vi.fn();
+    render(<MetadataConflictPanel book={conflictBook()} onResolve={onResolve} />);
+
+    expect(screen.getByRole('heading', { name: /providers disagree/i })).toBeInTheDocument();
+    fireEvent.click(screen.getByRole('button', { name: /use open library metadata/i }));
+
+    expect(onResolve).toHaveBeenCalledWith(expect.objectContaining({
+      title: 'OL Title',
+      author: 'Author B',
+      metadataSource: 'open_library',
+      needsReview: false,
+    }));
+  });
+
+  it('marks the active metadata source as pressed', () => {
+    render(<MetadataConflictPanel book={conflictBook()} onResolve={vi.fn()} />);
+    expect(screen.getByRole('button', { name: /use google books metadata/i })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: /use open library metadata/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+});

--- a/src/hooks/BookLookupProvider.tsx
+++ b/src/hooks/BookLookupProvider.tsx
@@ -1,0 +1,77 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from 'react';
+import {
+  beginLookupRequest,
+  isLookupRequestCurrent,
+  lookupBookMetadataDetailed,
+} from '../lib/bookLookupCore.ts';
+import type { BookMetadata, MetadataLookupPayload } from '../types.ts';
+
+export type { BookMetadata, MetadataLookupPayload } from '../types.ts';
+
+interface BookLookupContextValue {
+  lookupByIsbn: (isbn: string) => Promise<BookMetadata | null>;
+  lookupByIsbnDetailed: (isbn: string) => Promise<MetadataLookupPayload | null>;
+  loading: boolean;
+  error: string | null;
+}
+
+const BookLookupContext = createContext<BookLookupContextValue | null>(null);
+
+export function BookLookupProvider({ children }: { children: ReactNode }) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const lookupIdRef = useRef(0);
+
+  const lookupByIsbnDetailed = useCallback(async (isbn: string): Promise<MetadataLookupPayload | null> => {
+    const lookupId = beginLookupRequest();
+    lookupIdRef.current = lookupId;
+    setLoading(true);
+    setError(null);
+    try {
+      const { payload, error: lookupError } = await lookupBookMetadataDetailed(
+        isbn,
+        lookupId,
+        'useBookLookup.lookupByIsbnDetailed',
+      );
+      if (!isLookupRequestCurrent(lookupId)) return null;
+      setError(lookupError);
+      return payload;
+    } finally {
+      if (lookupIdRef.current === lookupId) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  const lookupByIsbn = useCallback(async (isbn: string): Promise<BookMetadata | null> => {
+    const payload = await lookupByIsbnDetailed(isbn);
+    return payload?.meta ?? null;
+  }, [lookupByIsbnDetailed]);
+
+  const value = useMemo(
+    () => ({ lookupByIsbn, lookupByIsbnDetailed, loading, error }),
+    [lookupByIsbn, lookupByIsbnDetailed, loading, error],
+  );
+
+  return (
+    <BookLookupContext.Provider value={value}>
+      {children}
+    </BookLookupContext.Provider>
+  );
+}
+
+export function useBookLookup(): BookLookupContextValue {
+  const context = useContext(BookLookupContext);
+  if (!context) {
+    throw new Error('useBookLookup must be used within BookLookupProvider');
+  }
+  return context;
+}

--- a/src/hooks/BookLookupProvider.tsx
+++ b/src/hooks/BookLookupProvider.tsx
@@ -68,6 +68,8 @@ export function BookLookupProvider({ children }: { children: ReactNode }) {
   );
 }
 
+// Hook export alongside provider — intentional colocation for lookup context.
+// eslint-disable-next-line react-refresh/only-export-components
 export function useBookLookup(): BookLookupContextValue {
   const context = useContext(BookLookupContext);
   if (!context) {

--- a/src/hooks/__tests__/BookLookupProvider.test.tsx
+++ b/src/hooks/__tests__/BookLookupProvider.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { describe, it, expect } from 'vitest';
 import { render, screen } from '@testing-library/react';
-import { BookLookupProvider, useBookLookup } from '../useBookLookup';
+import { BookLookupProvider, useBookLookup } from '../BookLookupProvider';
 
 function ReadLoading({ onReady }: { onReady: (loading: boolean) => void }) {
   const { loading } = useBookLookup();

--- a/src/hooks/__tests__/BookLookupProvider.test.tsx
+++ b/src/hooks/__tests__/BookLookupProvider.test.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BookLookupProvider, useBookLookup } from '../useBookLookup';
+
+function ReadLoading({ onReady }: { onReady: (loading: boolean) => void }) {
+  const { loading } = useBookLookup();
+  onReady(loading);
+  return <span>{loading ? 'loading' : 'idle'}</span>;
+}
+
+function Probe() {
+  const first = useBookLookup();
+  const second = useBookLookup();
+  return (
+    <span>
+      {first.loading || second.loading ? 'loading' : 'idle'}
+    </span>
+  );
+}
+
+describe('BookLookupProvider', () => {
+  it('shares loading state across consumers', () => {
+    const seen: boolean[] = [];
+    render(
+      <BookLookupProvider>
+        <ReadLoading onReady={(loading) => seen.push(loading)} />
+      </BookLookupProvider>,
+    );
+    expect(seen[0]).toBe(false);
+    expect(screen.getByText('idle')).toBeInTheDocument();
+  });
+
+  it('exposes one shared lookup instance to nested hooks', () => {
+    render(
+      <BookLookupProvider>
+        <Probe />
+      </BookLookupProvider>,
+    );
+    expect(screen.getByText('idle')).toBeInTheDocument();
+  });
+
+  it('throws when hook is used outside provider', () => {
+    const Broken = () => {
+      useBookLookup();
+      return null;
+    };
+    expect(() => render(<Broken />)).toThrow(/BookLookupProvider/);
+  });
+});

--- a/src/lib/__tests__/metadataApply.test.ts
+++ b/src/lib/__tests__/metadataApply.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect } from 'vitest';
+import { buildMetadataRefreshUpdates, recoverCoverFromBook } from '../metadataApply.ts';
+import type { BookEntry } from '../../types.ts';
+
+const baseBook = (): BookEntry => ({
+  id: 'b1',
+  isbn: '9780141036144',
+  title: 'Old',
+  author: 'Old Author',
+  pageCount: 10,
+  amazonLink: '',
+  coverImg: '',
+  status: 'to-read',
+  notes: '',
+  dateAdded: new Date().toISOString(),
+  shelfIds: [],
+});
+
+describe('buildMetadataRefreshUpdates', () => {
+  it('stores metadata peers when both providers return data', () => {
+    const { updates } = buildMetadataRefreshUpdates(
+      baseBook(),
+      {
+        title: 'New',
+        authors: ['A'],
+        pageCount: 200,
+        thumbnail: '',
+        isbn: '9780141036144',
+        source: 'google_books',
+        conflicts: [{ source: 'open_library', title: 'Alt', authors: ['B'], pageCount: 210, thumbnail: '', isbn: '9780141036144', reasons: ['author'] }],
+      },
+      {
+        title: 'New',
+        authors: ['A'],
+        pageCount: 200,
+        thumbnail: '',
+        isbn: '9780141036144',
+        source: 'google_books',
+      },
+      {
+        title: 'Alt',
+        authors: ['B'],
+        pageCount: 210,
+        thumbnail: 'https://covers.example/ol.jpg',
+        isbn: '9780141036144',
+        source: 'open_library',
+      },
+    );
+    expect(updates.metadataPeers?.google?.author).toBe('A');
+    expect(updates.metadataPeers?.openLibrary?.author).toBe('B');
+    expect(updates.needsReview).toBe(true);
+  });
+
+  it('does not overwrite user-edited fields', () => {
+    const book: BookEntry = {
+      ...baseBook(),
+      userEditedFields: { title: true, author: true },
+    };
+    const { updates } = buildMetadataRefreshUpdates(
+      book,
+      {
+        title: 'New',
+        authors: ['New Author'],
+        pageCount: 500,
+        thumbnail: 'https://covers.example/new.jpg',
+        isbn: '9780141036144',
+        source: 'google_books',
+      },
+      {
+        title: 'New',
+        authors: ['New Author'],
+        pageCount: 500,
+        thumbnail: 'https://covers.example/new.jpg',
+        isbn: '9780141036144',
+        source: 'google_books',
+      },
+      null,
+    );
+    expect(updates.title).toBeUndefined();
+    expect(updates.author).toBeUndefined();
+    expect(updates.pageCount).toBe(500);
+    expect(updates.coverImg).toBe('https://covers.example/new.jpg');
+  });
+
+  it('marks edition fallback for review', () => {
+    const { updates, reviewReasons } = buildMetadataRefreshUpdates(
+      baseBook(),
+      {
+        title: 'New',
+        authors: ['A'],
+        pageCount: 200,
+        thumbnail: '',
+        isbn: '9780141036144',
+        source: 'google_books',
+        editionFallback: true,
+        matchedIsbn: '0141036141',
+      },
+      null,
+      null,
+    );
+    expect(reviewReasons.some((reason) => reason.includes('alternate ISBN'))).toBe(true);
+    expect(updates.needsReview).toBe(true);
+  });
+});
+
+describe('recoverCoverFromBook', () => {
+  it('uses open library peer thumbnail when cover is empty', () => {
+    const book: BookEntry = {
+      ...baseBook(),
+      metadataPeers: {
+        openLibrary: { author: 'A', pageCount: 1, thumbnail: 'https://covers.example/ol.jpg' },
+      },
+    };
+    const patch = recoverCoverFromBook(book);
+    expect(patch?.coverImg).toBe('https://covers.example/ol.jpg');
+  });
+
+  it('returns null when cover was user-edited', () => {
+    const book: BookEntry = {
+      ...baseBook(),
+      userEditedFields: { coverImg: true },
+      metadataPeers: {
+        openLibrary: { author: 'A', pageCount: 1, thumbnail: 'https://covers.example/ol.jpg' },
+      },
+    };
+    expect(recoverCoverFromBook(book)).toBeNull();
+  });
+});

--- a/src/lib/__tests__/metadataCompare.test.ts
+++ b/src/lib/__tests__/metadataCompare.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest';
+import { pageCountsConflict } from '../metadataCompare.ts';
+
+describe('pageCountsConflict', () => {
+  it('returns false for small differences within threshold', () => {
+    expect(pageCountsConflict(300, 305)).toBe(false);
+  });
+
+  it('returns true when both counts are positive and differ beyond threshold', () => {
+    expect(pageCountsConflict(300, 320)).toBe(true);
+  });
+
+  it('returns false when either count is zero', () => {
+    expect(pageCountsConflict(0, 320)).toBe(false);
+  });
+});

--- a/src/lib/__tests__/metadataLookupCache.test.ts
+++ b/src/lib/__tests__/metadataLookupCache.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import type { MetadataLookupPayload } from '../types.ts';
+import {
+  clearPersistedLookupCache,
+  getPersistedLookup,
+  setPersistedLookup,
+} from '../metadataLookupCache.ts';
+
+const samplePayload = (): MetadataLookupPayload => ({
+  meta: {
+    title: 'Sample',
+    authors: ['Author'],
+    pageCount: 100,
+    thumbnail: '',
+    isbn: '9780141036144',
+    source: 'google_books',
+  },
+  google: null,
+  openLibrary: null,
+});
+
+describe('metadataLookupCache', () => {
+  beforeEach(() => {
+    clearPersistedLookupCache();
+  });
+
+  it('stores and retrieves payloads by cache key', () => {
+    setPersistedLookup('9780141036144', samplePayload());
+    expect(getPersistedLookup('9780141036144')?.meta.title).toBe('Sample');
+  });
+
+  it('returns null for missing keys', () => {
+    expect(getPersistedLookup('0000000000')).toBeNull();
+  });
+});

--- a/src/lib/__tests__/userEditedFields.test.ts
+++ b/src/lib/__tests__/userEditedFields.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { getUserEditedFields, withUserEditedFields } from '../userEditedFields.ts';
+import type { BookEntry } from '../../types.ts';
+
+const baseBook = (): BookEntry => ({
+  id: 'b1',
+  isbn: '9780141036144',
+  title: 'Title',
+  author: 'Author',
+  pageCount: 100,
+  amazonLink: '',
+  coverImg: '',
+  status: 'to-read',
+  notes: '',
+  dateAdded: new Date().toISOString(),
+  shelfIds: [],
+});
+
+describe('getUserEditedFields', () => {
+  it('merges legacy and current edited-field maps', () => {
+    const book: BookEntry = {
+      ...baseBook(),
+      metadataUserEdited: { title: true },
+      userEditedFields: { coverImg: true },
+    };
+    expect(getUserEditedFields(book)).toEqual({ title: true, coverImg: true });
+  });
+});
+
+describe('withUserEditedFields', () => {
+  it('clears both aliases when fields are empty', () => {
+    expect(withUserEditedFields(baseBook(), undefined)).toEqual({
+      userEditedFields: undefined,
+      metadataUserEdited: undefined,
+    });
+  });
+
+  it('mirrors edited flags to both aliases', () => {
+    const fields = { author: true };
+    expect(withUserEditedFields(baseBook(), fields)).toEqual({
+      userEditedFields: fields,
+      metadataUserEdited: fields,
+    });
+  });
+});

--- a/src/lib/bookLookupCore.ts
+++ b/src/lib/bookLookupCore.ts
@@ -1,0 +1,284 @@
+import { isbn13To10, isbn10To13 } from '../utils/isbnValidation.ts';
+import { addBreadcrumb, captureException } from '../lib/errorMonitoring.ts';
+import { normalizeComparableText, pageCountsConflict } from '../lib/metadataCompare.ts';
+import {
+  clearPersistedLookupCache,
+  getPersistedLookup,
+  setPersistedLookup,
+} from '../lib/metadataLookupCache.ts';
+import type { BookMetadata, MetadataLookupPayload, MetadataSource } from '../types.ts';
+
+const memoryCache = new Map<string, BookMetadata>();
+const detailedMemoryCache = new Map<string, MetadataLookupPayload>();
+
+export const normalizeIsbnKey = (isbn: string): string => isbn.replace(/[^0-9Xx]/g, '').toUpperCase();
+
+let lastCallTime = 0;
+let activeLookupId = 0;
+
+const pickPrimaryMetadata = (
+  requestedIsbn: string,
+  candidates: BookMetadata[],
+): BookMetadata | null => {
+  if (candidates.length === 0) return null;
+  const key = normalizeIsbnKey(requestedIsbn);
+  const exact = candidates.find((candidate) => normalizeIsbnKey(candidate.isbn) === key);
+  if (exact) return exact;
+  return candidates.find((candidate) => candidate.source === 'google_books') ?? candidates[0] ?? null;
+};
+
+const delay = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+const fetchWithRetry = async (url: string, retries = 2): Promise<Response> => {
+  for (let attempt = 0; attempt <= retries; attempt += 1) {
+    try {
+      const response = await fetch(url);
+      if (response.ok) return response;
+      if (response.status >= 500 && attempt < retries) {
+        await delay(1000 * 2 ** attempt);
+        continue;
+      }
+      return response;
+    } catch (err) {
+      if (attempt < retries) {
+        await delay(1000 * 2 ** attempt);
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw new Error('Max retries exceeded');
+};
+
+const getConflictReasons = (primary: BookMetadata, other: BookMetadata): string[] => {
+  const reasons: string[] = [];
+  if (normalizeComparableText(primary.title) !== normalizeComparableText(other.title)) reasons.push('title');
+  if (normalizeComparableText(primary.authors.join(', ')) !== normalizeComparableText(other.authors.join(', '))) {
+    reasons.push('author');
+  }
+  if (pageCountsConflict(primary.pageCount, other.pageCount)) reasons.push('page count');
+  if (!primary.thumbnail && other.thumbnail) reasons.push('cover');
+  return reasons;
+};
+
+const attachMetadataContext = (
+  primary: BookMetadata,
+  candidates: Array<BookMetadata | null>,
+  requestedIsbn: string,
+): BookMetadata => {
+  const conflicts = candidates
+    .filter((candidate): candidate is BookMetadata => candidate != null && candidate.source !== primary.source)
+    .map((candidate) => ({ candidate, reasons: getConflictReasons(primary, candidate) }))
+    .filter(({ reasons }) => reasons.length > 0)
+    .map(({ candidate, reasons }) => ({
+      source: candidate.source as MetadataSource,
+      title: candidate.title,
+      authors: candidate.authors,
+      pageCount: candidate.pageCount,
+      thumbnail: candidate.thumbnail,
+      isbn: candidate.isbn,
+      reasons,
+    }));
+
+  const bestCover = primary.thumbnail || candidates.find((candidate) => candidate?.thumbnail)?.thumbnail || '';
+  return {
+    ...primary,
+    isbn: requestedIsbn,
+    matchedIsbn: primary.isbn,
+    thumbnail: bestCover,
+    editionFallback: normalizeIsbnKey(primary.isbn) !== normalizeIsbnKey(requestedIsbn),
+    ...(conflicts.length > 0 ? { conflicts } : {}),
+  };
+};
+
+const lookupGoogleBooks = async (isbn: string): Promise<BookMetadata | null> => {
+  const response = await fetchWithRetry(
+    `https://www.googleapis.com/books/v1/volumes?q=isbn:${isbn}`,
+  );
+  if (!response.ok) return null;
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    return null;
+  }
+
+  if (!data || typeof data !== 'object') return null;
+  const payload = data as { totalItems?: number; items?: Array<{ volumeInfo?: Record<string, unknown> }> };
+  if (!payload.totalItems || payload.totalItems === 0) return null;
+  if (!Array.isArray(payload.items) || payload.items.length === 0) return null;
+
+  const volumeInfo = payload.items[0]?.volumeInfo;
+  if (!volumeInfo) return null;
+
+  const imageLinks = volumeInfo.imageLinks as { thumbnail?: string } | undefined;
+  const authors = volumeInfo.authors as string[] | undefined;
+
+  return {
+    title: (volumeInfo.title as string | undefined) || 'Unknown Title',
+    authors: authors?.length ? authors : ['Unknown Author'],
+    pageCount: (volumeInfo.pageCount as number | undefined) || 0,
+    thumbnail: imageLinks?.thumbnail || '',
+    isbn,
+    source: 'google_books',
+  };
+};
+
+const lookupOpenLibrary = async (isbn: string): Promise<BookMetadata | null> => {
+  const response = await fetchWithRetry(
+    `https://openlibrary.org/api/books?bibkeys=ISBN:${isbn}&format=json&jscmd=data`,
+  );
+  if (!response.ok) return null;
+
+  let data: unknown;
+  try {
+    data = await response.json();
+  } catch {
+    return null;
+  }
+
+  if (!data || typeof data !== 'object') return null;
+  const entry = (data as Record<string, {
+    title?: string;
+    authors?: Array<{ name: string }>;
+    number_of_pages?: number;
+    cover?: { medium?: string; small?: string };
+  }>)[`ISBN:${isbn}`];
+  if (!entry) return null;
+
+  return {
+    title: entry.title || 'Unknown Title',
+    authors: entry.authors?.map((a) => a.name) || ['Unknown Author'],
+    pageCount: entry.number_of_pages || 0,
+    thumbnail: entry.cover?.medium || entry.cover?.small || '',
+    isbn,
+    source: 'open_library',
+  };
+};
+
+const settleMetadataLookups = async (isbn: string): Promise<Array<BookMetadata | null>> => {
+  const results = await Promise.allSettled([
+    lookupGoogleBooks(isbn),
+    lookupOpenLibrary(isbn),
+  ]);
+
+  if (results.every((result) => result.status === 'rejected')) {
+    const firstRejected = results.find((result): result is PromiseRejectedResult => result.status === 'rejected');
+    throw firstRejected?.reason ?? new Error('Metadata lookup failed');
+  }
+
+  return results.map((result) => (result.status === 'fulfilled' ? result.value : null));
+};
+
+function rememberLookup(cacheKey: string, payload: MetadataLookupPayload): void {
+  detailedMemoryCache.set(cacheKey, payload);
+  memoryCache.set(cacheKey, payload.meta);
+  setPersistedLookup(cacheKey, payload);
+}
+
+export function clearBookLookupCaches(): void {
+  memoryCache.clear();
+  detailedMemoryCache.clear();
+  clearPersistedLookupCache();
+}
+
+export function clearMemoryBookLookupCaches(): void {
+  memoryCache.clear();
+  detailedMemoryCache.clear();
+}
+
+export function beginLookupRequest(): number {
+  return ++activeLookupId;
+}
+
+export function isLookupRequestCurrent(lookupId: number): boolean {
+  return lookupId === activeLookupId;
+}
+
+export async function performBookLookup(
+  isbn: string,
+  lookupId: number,
+): Promise<MetadataLookupPayload | null> {
+  const cacheKey = normalizeIsbnKey(isbn);
+  const cachedDetailed = detailedMemoryCache.get(cacheKey) ?? getPersistedLookup(cacheKey);
+  if (cachedDetailed) {
+    detailedMemoryCache.set(cacheKey, cachedDetailed);
+    memoryCache.set(cacheKey, cachedDetailed.meta);
+    addBreadcrumb('metadata', 'Lookup cache hit', { isbnLength: isbn.length });
+    return cachedDetailed;
+  }
+
+  const now = Date.now();
+  const elapsed = now - lastCallTime;
+  if (elapsed < 300) {
+    await delay(300 - elapsed);
+  }
+  lastCallTime = Date.now();
+
+  if (!isLookupRequestCurrent(lookupId)) return null;
+
+  addBreadcrumb('metadata', 'Lookup started', { isbnLength: isbn.length });
+  const [googleResult, openLibraryResult] = await settleMetadataLookups(isbn);
+  if (!isLookupRequestCurrent(lookupId)) return null;
+
+  const directCandidates = [googleResult, openLibraryResult].filter(
+    (candidate): candidate is BookMetadata => candidate != null,
+  );
+
+  let google = googleResult;
+  let openLibrary = openLibraryResult;
+  let allCandidates = [...directCandidates];
+
+  if (directCandidates.length === 0) {
+    const alt = isbn.length === 13 ? isbn13To10(isbn) : isbn10To13(isbn);
+    if (alt) {
+      const [altGoogleResult, altOpenLibraryResult] = await settleMetadataLookups(alt);
+      if (!isLookupRequestCurrent(lookupId)) return null;
+      google = altGoogleResult;
+      openLibrary = altOpenLibraryResult;
+      allCandidates = [altGoogleResult, altOpenLibraryResult].filter(
+        (candidate): candidate is BookMetadata => candidate != null,
+      );
+    }
+  }
+
+  const primary = pickPrimaryMetadata(isbn, allCandidates);
+  if (!primary) {
+    addBreadcrumb('metadata', 'Lookup returned no results', { isbnLength: isbn.length });
+    return null;
+  }
+
+  const meta = attachMetadataContext(primary, [google, openLibrary, ...allCandidates], isbn);
+  const payload: MetadataLookupPayload = { meta, google, openLibrary };
+  rememberLookup(cacheKey, payload);
+  addBreadcrumb('metadata', 'Lookup succeeded', {
+    isbnLength: isbn.length,
+    pageCount: meta.pageCount,
+    authorCount: meta.authors.length,
+  });
+  return payload;
+}
+
+export async function lookupBookMetadataDetailed(
+  isbn: string,
+  lookupId: number,
+  area: string,
+): Promise<{ payload: MetadataLookupPayload | null; error: string | null }> {
+  try {
+    const payload = await performBookLookup(isbn, lookupId);
+    if (!isLookupRequestCurrent(lookupId)) {
+      return { payload: null, error: null };
+    }
+    if (!payload) {
+      return { payload: null, error: 'No book found with this ISBN' };
+    }
+    return { payload, error: null };
+  } catch (lookupError) {
+    if (isLookupRequestCurrent(lookupId)) {
+      captureException(lookupError, { area, isbnLength: isbn.length });
+      return { payload: null, error: 'Failed to fetch book metadata' };
+    }
+    return { payload: null, error: null };
+  }
+}

--- a/src/lib/metadataApply.ts
+++ b/src/lib/metadataApply.ts
@@ -1,0 +1,95 @@
+import type { BookEntry, BookLookupResult, BookMetadata } from '../types.ts';
+import { generateAmazonLink } from '../utils/amazonLink.ts';
+import { hasRealCover } from '../utils/bookPresentation.ts';
+import { getMetadataConflictFlags } from './metadataPeers.ts';
+import { applyMetadataRefresh } from './metadataRefresh.ts';
+import { getUserEditedFields } from './userEditedFields.ts';
+
+export function toBookLookupResult(
+  meta: BookMetadata,
+  google: BookMetadata | null,
+  openLibrary: BookMetadata | null,
+): BookLookupResult {
+  return {
+    title: meta.title,
+    authors: meta.authors,
+    pageCount: meta.pageCount,
+    thumbnail: meta.thumbnail,
+    isbn: meta.isbn,
+    metadataSource: meta.source ?? 'manual',
+    google,
+    openLibrary,
+  };
+}
+
+export function buildMetadataRefreshUpdates(
+  book: BookEntry,
+  meta: BookMetadata,
+  google: BookMetadata | null,
+  openLibrary: BookMetadata | null,
+): { updates: Partial<BookEntry>; reviewReasons: string[] } {
+  const lookup = toBookLookupResult(meta, google, openLibrary);
+  const bookForRefresh: BookEntry = {
+    ...book,
+    metadataUserEdited: getUserEditedFields(book),
+  };
+  const updates = applyMetadataRefresh(bookForRefresh, lookup);
+  if (updates.metadataUserEdited) {
+    updates.userEditedFields = updates.metadataUserEdited;
+  }
+
+  const reviewReasons: string[] = [];
+  if (meta.editionFallback) {
+    reviewReasons.push(`Matched alternate ISBN edition ${meta.matchedIsbn ?? meta.isbn}.`);
+  }
+  if (meta.conflicts?.length) {
+    const fields = [...new Set(meta.conflicts.flatMap((conflict) => conflict.reasons))].join(', ');
+    reviewReasons.push(`Metadata providers disagree on ${fields}.`);
+  }
+
+  const mergedCover = updates.coverImg ?? book.coverImg;
+  if (!hasRealCover(mergedCover)) {
+    reviewReasons.push('No cover image found.');
+  }
+
+  const peersBook: BookEntry = { ...book, ...updates };
+  const conflictFlags = getMetadataConflictFlags(peersBook);
+  const hasPeerConflict = conflictFlags.author || conflictFlags.pageCount || conflictFlags.title;
+
+  if (reviewReasons.length > 0 || hasPeerConflict) {
+    updates.needsReview = true;
+    updates.reviewReason = reviewReasons.length > 0
+      ? reviewReasons.join(' ')
+      : 'Metadata providers disagree — pick a source below.';
+  }
+
+  return { updates, reviewReasons };
+}
+
+/** Try peer snapshots or a fresh lookup thumbnail when the row has no real cover. */
+export function recoverCoverFromBook(
+  book: BookEntry,
+  meta?: BookMetadata | null,
+): Partial<BookEntry> | null {
+  const edited = getUserEditedFields(book);
+  if (edited.coverImg) return null;
+
+  const fromPeers =
+    book.metadataPeers?.google?.thumbnail?.trim()
+    || book.metadataPeers?.openLibrary?.thumbnail?.trim()
+    || '';
+  const fromMeta = meta?.thumbnail?.trim() || '';
+  const fromConflicts = meta?.conflicts?.find((c) => c.thumbnail)?.thumbnail?.trim() || '';
+  const next = fromPeers || fromMeta || fromConflicts;
+  if (!hasRealCover(next)) return null;
+
+  const updates: Partial<BookEntry> = {
+    coverImg: next,
+    amazonLink: generateAmazonLink(book.isbn),
+  };
+  if (book.reviewReason?.toLowerCase().includes('cover')) {
+    updates.needsReview = false;
+    updates.reviewReason = '';
+  }
+  return updates;
+}

--- a/src/lib/metadataCompare.ts
+++ b/src/lib/metadataCompare.ts
@@ -1,0 +1,9 @@
+/** Page-count delta above which two metadata sources are treated as conflicting. */
+export const PAGE_COUNT_CONFLICT_THRESHOLD = 10;
+
+export function pageCountsConflict(a: number, b: number): boolean {
+  return a > 0 && b > 0 && Math.abs(a - b) > PAGE_COUNT_CONFLICT_THRESHOLD;
+}
+
+export const normalizeComparableText = (value: string): string =>
+  value.trim().toLowerCase().replace(/[^\p{L}\p{N}]+/gu, ' ').replace(/\s+/g, ' ').trim();

--- a/src/lib/metadataLookupCache.ts
+++ b/src/lib/metadataLookupCache.ts
@@ -1,0 +1,61 @@
+import type { MetadataLookupPayload } from '../types.ts';
+
+const STORAGE_KEY = 'spine-metadata-lookup-cache-v1';
+const TTL_MS = 7 * 24 * 60 * 60 * 1000;
+const MAX_ENTRIES = 100;
+
+interface PersistedEntry {
+  savedAt: number;
+  payload: MetadataLookupPayload;
+}
+
+type PersistedStore = Record<string, PersistedEntry>;
+
+function readStore(): PersistedStore {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as PersistedStore;
+    return parsed && typeof parsed === 'object' ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: PersistedStore): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    /* quota or private mode — ignore */
+  }
+}
+
+function pruneStore(store: PersistedStore): PersistedStore {
+  const now = Date.now();
+  const freshEntries = Object.entries(store).filter(([, entry]) => now - entry.savedAt <= TTL_MS);
+  freshEntries.sort((a, b) => b[1].savedAt - a[1].savedAt);
+  return Object.fromEntries(freshEntries.slice(0, MAX_ENTRIES));
+}
+
+export function getPersistedLookup(cacheKey: string): MetadataLookupPayload | null {
+  const store = pruneStore(readStore());
+  writeStore(store);
+  const entry = store[cacheKey];
+  if (!entry) return null;
+  if (Date.now() - entry.savedAt > TTL_MS) return null;
+  return entry.payload;
+}
+
+export function setPersistedLookup(cacheKey: string, payload: MetadataLookupPayload): void {
+  const store = pruneStore(readStore());
+  store[cacheKey] = { savedAt: Date.now(), payload };
+  writeStore(pruneStore(store));
+}
+
+export function clearPersistedLookupCache(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    /* ignore */
+  }
+}

--- a/src/lib/metadataPeers.ts
+++ b/src/lib/metadataPeers.ts
@@ -1,0 +1,58 @@
+import type { BookEntry, BookMetadata, MetadataPeerSnapshot, MetadataSource } from '../types.ts';
+import { generateAmazonLink } from '../utils/amazonLink.ts';
+import { normalizeComparableText, pageCountsConflict } from './metadataCompare.ts';
+
+export function toMetadataPeerSnapshot(meta: BookMetadata): MetadataPeerSnapshot {
+  return {
+    title: meta.title,
+    author: meta.authors.join(', '),
+    pageCount: meta.pageCount,
+    thumbnail: meta.thumbnail,
+  };
+}
+
+export function getMetadataConflictFlags(book: BookEntry): {
+  author: boolean;
+  pageCount: boolean;
+  title: boolean;
+} {
+  const google = book.metadataPeers?.google;
+  const openLibrary = book.metadataPeers?.openLibrary;
+  if (!google || !openLibrary) {
+    return { author: false, pageCount: false, title: false };
+  }
+
+  return {
+    title:
+      normalizeComparableText(google.title ?? book.title)
+      !== normalizeComparableText(openLibrary.title ?? book.title),
+    author: normalizeComparableText(google.author) !== normalizeComparableText(openLibrary.author),
+    pageCount: pageCountsConflict(google.pageCount, openLibrary.pageCount),
+  };
+}
+
+export function applyMetadataPeerChoice(
+  book: BookEntry,
+  provider: Extract<MetadataSource, 'google_books' | 'open_library'>,
+): Partial<BookEntry> | null {
+  const peer = provider === 'google_books'
+    ? book.metadataPeers?.google
+    : book.metadataPeers?.openLibrary;
+  if (!peer) return null;
+
+  const updates: Partial<BookEntry> = {
+    title: peer.title?.trim() || book.title,
+    author: peer.author,
+    pageCount: peer.pageCount > 0 ? peer.pageCount : book.pageCount,
+    metadataSource: provider,
+    needsReview: false,
+    reviewReason: '',
+    amazonLink: generateAmazonLink(book.isbn),
+  };
+
+  if (peer.thumbnail?.trim()) {
+    updates.coverImg = peer.thumbnail.trim();
+  }
+
+  return updates;
+}

--- a/src/lib/metadataRefresh.ts
+++ b/src/lib/metadataRefresh.ts
@@ -1,0 +1,35 @@
+import type { BookEntry, BookLookupResult, BookMetadata } from '../types.ts';
+import { generateAmazonLink } from '../utils/amazonLink.ts';
+import { getUserEditedFields } from './userEditedFields.ts';
+import { toMetadataPeerSnapshot } from './metadataPeers.ts';
+
+export function applyMetadataRefresh(
+  book: BookEntry,
+  lookup: BookLookupResult,
+): Partial<BookEntry> {
+  const edited = getUserEditedFields(book);
+  const updates: Partial<BookEntry> = {
+    metadataSource: lookup.metadataSource,
+    metadataPeers: {
+      ...(lookup.google ? { google: toMetadataPeerSnapshot(lookup.google) } : {}),
+      ...(lookup.openLibrary ? { openLibrary: toMetadataPeerSnapshot(lookup.openLibrary) } : {}),
+    },
+  };
+
+  if (!edited.title) updates.title = lookup.title;
+  if (!edited.author) updates.author = lookup.authors.join(', ');
+  if (!edited.pageCount) updates.pageCount = lookup.pageCount;
+  if (!edited.coverImg && lookup.thumbnail.trim()) {
+    updates.coverImg = lookup.thumbnail;
+  }
+
+  if (!book.amazonLink || updates.coverImg) {
+    updates.amazonLink = generateAmazonLink(book.isbn);
+  }
+
+  return updates;
+}
+
+export function peerSnapshotFromMetadata(meta: BookMetadata) {
+  return toMetadataPeerSnapshot(meta);
+}

--- a/src/lib/userEditedFields.ts
+++ b/src/lib/userEditedFields.ts
@@ -1,0 +1,16 @@
+import type { BookEntry, UserEditedFields } from '../types.ts';
+
+/** Unified view of manual-edit flags (supports legacy `metadataUserEdited`). */
+export function getUserEditedFields(book: BookEntry): UserEditedFields {
+  return { ...(book.metadataUserEdited ?? {}), ...(book.userEditedFields ?? {}) };
+}
+
+export function withUserEditedFields(
+  _book: BookEntry,
+  fields: UserEditedFields | undefined,
+): Pick<BookEntry, 'userEditedFields' | 'metadataUserEdited'> {
+  if (!fields || Object.keys(fields).length === 0) {
+    return { userEditedFields: undefined, metadataUserEdited: undefined };
+  }
+  return { userEditedFields: fields, metadataUserEdited: fields };
+}

--- a/src/pwa/updateRegistration.ts
+++ b/src/pwa/updateRegistration.ts
@@ -1,0 +1,38 @@
+type RefreshListener = (needRefresh: boolean) => void;
+
+const listeners = new Set<RefreshListener>();
+let needRefresh = false;
+let updateServiceWorker: ((reloadPage?: boolean) => Promise<void>) | null = null;
+
+export function subscribePwaRefresh(listener: RefreshListener): () => void {
+  listeners.add(listener);
+  listener(needRefresh);
+  return () => listeners.delete(listener);
+}
+
+export function dismissPwaRefresh(): void {
+  needRefresh = false;
+  listeners.forEach((listener) => listener(false));
+}
+
+export async function applyPwaUpdate(): Promise<void> {
+  if (updateServiceWorker) {
+    await updateServiceWorker(true);
+  }
+}
+
+export function initPwaUpdateRegistration(): void {
+  if (!('serviceWorker' in navigator)) return;
+
+  void import('virtual:pwa-register').then(({ registerSW }) => {
+    updateServiceWorker = registerSW({
+      immediate: true,
+      onNeedRefresh() {
+        needRefresh = true;
+        listeners.forEach((listener) => listener(true));
+      },
+    });
+  }).catch(() => {
+    /* dev/test without built SW */
+  });
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,8 +33,63 @@ export interface BookEntry {
    * A subsequent "Refresh metadata" must not overwrite flagged fields.
    */
   userEditedFields?: UserEditedFields;
+  /** @deprecated Use userEditedFields — kept for legacy rows. */
+  metadataUserEdited?: UserEditedFields;
+  /** Snapshots from Google Books and Open Library for conflict resolution. */
+  metadataPeers?: BookMetadataPeers;
   /** Schema version of this book entry; bumped when migrations are added. */
   schemaVersion?: number;
+}
+
+export interface MetadataPeerSnapshot {
+  title?: string;
+  author: string;
+  pageCount: number;
+  thumbnail?: string;
+}
+
+export interface BookMetadataPeers {
+  google?: MetadataPeerSnapshot;
+  openLibrary?: MetadataPeerSnapshot;
+}
+
+export interface BookMetadata {
+  title: string;
+  authors: string[];
+  pageCount: number;
+  thumbnail: string;
+  isbn: string;
+  source: MetadataSource;
+  matchedIsbn?: string;
+  editionFallback?: boolean;
+  conflicts?: MetadataProviderConflict[];
+}
+
+export interface MetadataProviderConflict {
+  source: MetadataSource;
+  title: string;
+  authors: string[];
+  pageCount: number;
+  thumbnail: string;
+  isbn: string;
+  reasons: string[];
+}
+
+export interface BookLookupResult {
+  title: string;
+  authors: string[];
+  pageCount: number;
+  thumbnail: string;
+  isbn: string;
+  metadataSource: MetadataSource;
+  google: BookMetadata | null;
+  openLibrary: BookMetadata | null;
+}
+
+export interface MetadataLookupPayload {
+  meta: BookMetadata;
+  google: BookMetadata | null;
+  openLibrary: BookMetadata | null;
 }
 
 export type MetadataSource = 'google_books' | 'open_library' | 'manual';

--- a/src/utils/__tests__/network.test.ts
+++ b/src/utils/__tests__/network.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'vitest';
+import { isOnline, offlineMetadataMessage, parseOptionalPageCount } from '../network.ts';
+
+describe('network helpers', () => {
+  it('returns null for invalid page filter input', () => {
+    expect(parseOptionalPageCount('')).toBeNull();
+    expect(parseOptionalPageCount('abc')).toBeNull();
+  });
+
+  it('parses valid page counts', () => {
+    expect(parseOptionalPageCount('250')).toBe(250);
+  });
+
+  it('reports online status from navigator', () => {
+    expect(typeof isOnline()).toBe('boolean');
+  });
+
+  it('provides offline metadata guidance', () => {
+    expect(offlineMetadataMessage()).toMatch(/offline/i);
+  });
+});

--- a/src/utils/bookPresentation.ts
+++ b/src/utils/bookPresentation.ts
@@ -25,6 +25,12 @@ export function getBookCoverSrc(coverImg?: string): string {
   return coverImg?.trim() ? coverImg : FALLBACK_COVER_DATA_URL;
 }
 
+export function hasRealCover(coverImg?: string): boolean {
+  const trimmed = coverImg?.trim();
+  if (!trimmed) return false;
+  return trimmed !== FALLBACK_COVER_DATA_URL;
+}
+
 export function getLibraryInsights(books: BookEntry[]): LibraryInsights {
   const readingCount = books.filter((book) => book.status === 'reading').length;
   const readCount = books.filter((book) => book.status === 'read').length;

--- a/src/utils/network.ts
+++ b/src/utils/network.ts
@@ -1,0 +1,14 @@
+export function isOnline(): boolean {
+  return typeof navigator === 'undefined' || navigator.onLine;
+}
+
+export function offlineMetadataMessage(): string {
+  return 'You appear to be offline. Connect to the internet to refresh metadata.';
+}
+
+export function parseOptionalPageCount(raw: string): number | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+  const value = parseInt(trimmed, 10);
+  return Number.isFinite(value) && value >= 0 ? value : null;
+}

--- a/src/utils/recentLibrarySearch.ts
+++ b/src/utils/recentLibrarySearch.ts
@@ -1,0 +1,35 @@
+const STORAGE_KEY = 'spine-recent-library-searches';
+const MAX_RECENT = 8;
+
+export function loadRecentLibrarySearches(): string[] {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter((entry): entry is string => typeof entry === 'string' && entry.trim().length > 0);
+  } catch {
+    return [];
+  }
+}
+
+export function rememberLibrarySearch(term: string): string[] {
+  const trimmed = term.trim();
+  if (trimmed.length < 2) return loadRecentLibrarySearches();
+  const lowered = trimmed.toLowerCase();
+  const next = [trimmed, ...loadRecentLibrarySearches().filter((q) => q.toLowerCase() !== lowered)].slice(0, MAX_RECENT);
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore quota errors
+  }
+  return next;
+}
+
+export function clearRecentLibrarySearches(): void {
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // ignore
+  }
+}

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -1,4 +1,5 @@
 /// <reference types="vite/client" />
+/// <reference types="vite-plugin-pwa/vanillajs" />
 
 interface ImportMetaEnv {
   readonly VITE_SUPABASE_URL?: string;


### PR DESCRIPTION
## Summary
- Raise Playwright OCR upload test timeout to 180s in CI (was 60s, shorter than the 120s success assertion)
- Extend OCR Heavy Checks workflow E2E step from 15 to 20 minutes

## Test plan
- [ ] OCR Heavy Checks workflow passes on this PR
- [ ] Lint, Test & Build check passes

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add multi-provider metadata conflict resolution and PWA update prompt to book library
> - Adds `MetadataConflictPanel` component that lets users choose between Google Books and Open Library metadata when providers disagree on title, author, or page count.
> - Introduces `bookLookupCore` with cached, throttled, multi-provider ISBN lookups including alternate ISBN fallback, conflict detection, and persisted results (7-day TTL, 100-entry cap).
> - Adds `PwaUpdatePrompt` component that surfaces a reload/dismiss alert when a new service worker update is available via `updateRegistration`.
> - Adds `BookLookupProvider` React context for shared, cancellable ISBN lookup state across components.
> - Extends E2E coverage with metadata conflict resolution and bulk refresh tests, and raises OCR upload timeout to 3 minutes on CI.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d276471.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->