### PR TITLE
fix: dedupe Goodreads import feedback; surface unknown-isbn deep links

### DIFF
--- a/e2e/recent-features.spec.ts
+++ b/e2e/recent-features.spec.ts
@@ -193,10 +193,8 @@ test.describe('Recent feature waves', () => {
     await expect(fileInput).toHaveCount(1);
     await fileInput.setInputFiles(GOODREADS_CSV);
 
-    // Inline result message: "Imported N books (M duplicates skipped)" or similar.
-    // Scope to the <p> element — the importer also fires a toast with the same
-    // text (a <span>), so an unscoped getByText is a strict-mode violation.
-    await expect(page.locator('p', { hasText: /imported \d+ book/i })).toBeVisible({ timeout: 10_000 });
+    // Inline result message: "Imported N books (M duplicates skipped)".
+    await expect(page.getByText(/imported \d+ book/i)).toBeVisible({ timeout: 10_000 });
 
     // Books should appear in the library after import.
     await page.getByTestId(uiContracts.navTabTestId('library')).click();

--- a/src/components/DataManagement.tsx
+++ b/src/components/DataManagement.tsx
@@ -154,7 +154,6 @@ const DataManagement: React.FC<DataManagementProps> = ({ onClose }) => {
             }
             const msg = `Imported ${imported.length} book${imported.length !== 1 ? 's' : ''} (${skipped} duplicate${skipped !== 1 ? 's' : ''} skipped)`;
             setGoodreadsMsg(msg);
-            toast(msg, 'success');
         };
         reader.readAsText(file);
         // reset input so same file can be re-imported

--- a/src/components/LibraryList.tsx
+++ b/src/components/LibraryList.tsx
@@ -326,9 +326,13 @@ export default function LibraryList({ onStartScanning, initialOpenIsbn, onOpenCo
   useEffect(() => {
     if (!initialOpenIsbn) return;
     const book = books.find((entry) => entry.isbn === initialOpenIsbn);
-    if (book) setSelectedBook(book);
+    if (book) {
+      setSelectedBook(book);
+    } else {
+      toast(`No book with ISBN ${initialOpenIsbn} in your library`, 'info');
+    }
     onOpenComplete?.();
-  }, [initialOpenIsbn, books, onOpenComplete]);
+  }, [initialOpenIsbn, books, onOpenComplete, toast]);
 
   useEffect(() => {
     if (initialSeriesFilter) setSeriesFilter(initialSeriesFilter);


### PR DESCRIPTION
## Summary

Two small polish fixes shaken out of the last CI dig into `recent-features.spec.ts`.

- **DataManagement — Goodreads import**: `handleGoodreadsImport` used to fire both an inline `<p>` message and a matching toast, showing the same text twice and (incidentally) tripping Playwright strict-mode. Drop the toast so the inline result is the single source of truth.
- **LibraryList — `?isbn=` deep link miss**: the `initialOpenIsbn` effect used to silently clear the URL when the isbn didn't match any book in the library. Now it surfaces an info toast (`"No book with ISBN … in your library"`) before clearing, so a stale share link is visibly a no-op instead of an invisible one.
- **E2E**: the Goodreads assertion is back to a plain `getByText(/imported \d+ book/i)` now that only one element carries the text.

## Checklist

- [x] CI is green (Lint, Test & Build) — 914 unit tests + 7 recent-features E2E all pass locally
- [ ] Updated **CHANGELOG.md** `## Unreleased` if the change is user-facing
- [ ] Ran or verified the **E2E MVP workflow** if this PR touches `appMode`, navigation, profile, or library behavior


---
_Generated by [Claude Code](https://claude.ai/code/session_01SqroB9H7EtDEKqJ885iFUF)_

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix duplicate Goodreads import feedback and surface toast for unknown ISBN deep links
> - Removes the success toast emitted after a Goodreads CSV import in [DataManagement.tsx](https://github.com/hondoentertainment/spine-scanner/pull/82/files#diff-7b0acf467a6b8dbccdf8ddc9a22c6fa474b1c4c52ce16f8deb2ecc075867b5fb), leaving only the inline result message to avoid duplicate feedback.
> - Shows an informational toast in [LibraryList.tsx](https://github.com/hondoentertainment/spine-scanner/pull/82/files#diff-174ff697c939b76b64b9831cf0c18e74c685d07fbae4c7175da5c26598d91b83) when an `initialOpenIsbn` deep-link target is not found in the library.
> - Updates the e2e assertion in [recent-features.spec.ts](https://github.com/hondoentertainment/spine-scanner/pull/82/files#diff-317c593172ccac5476c67d236b7e17b096b9f60c4d373eda482c0f42d41ee955) to match the import result message by text rather than by `<p>` element scope.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 39adc79.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->